### PR TITLE
Convert queries to promises, useMasterKey

### DIFF
--- a/cloud/Community.js
+++ b/cloud/Community.js
@@ -55,21 +55,21 @@ function incrementCommunityTotalsForKey(community, key, response) {
 
 	CommunityTotals.getAllTimeTotals(community, function(allTimeTotals) {
 		allTimeTotals.increment(key);
-		allTimeTotals.save();
+		allTimeTotals.save({},{ useMasterKey: true });
 		if (--queryCount == 0) {
 			response.success();
 		}
 	});
 	CommunityTotals.getDailyTotals(community, currDate, function(dailyTotals) {
 		dailyTotals.increment(key);
-		dailyTotals.save();
+		dailyTotals.save({},{ useMasterKey: true });
 		if (--queryCount == 0) {
 			response.success();
 		}
 	});
 	CommunityTotals.getMonthlyTotals(community, currDate, function(monthlyTotals) {
 		monthlyTotals.increment(key);
-		monthlyTotals.save();
+		monthlyTotals.save({},{ useMasterKey: true });
 		if (--queryCount == 0) {
 			response.success();
 		}

--- a/cloud/CommunityTotals.js
+++ b/cloud/CommunityTotals.js
@@ -5,8 +5,8 @@ exports.getAllTimeTotals = function(community, callback) {
 	var CommunityAllTimeTotals = Parse.Object.extend("CommunityAllTimeTotals");
 	var totalQuery = new Parse.Query(CommunityAllTimeTotals);
 	totalQuery.equalTo("community", community);
-	totalQuery.first({
-		success: function(object) {
+	totalQuery.first().then(
+		function(object) { // success
 			var allTimeTotals = object;
 			if (!allTimeTotals) {
 				console.log("CommunityAllTimeTotals not found, creating");
@@ -24,10 +24,10 @@ exports.getAllTimeTotals = function(community, callback) {
 			}
 			callback(allTimeTotals);
 		},
-		error: function(error) {
+		function(error) { // error
 			console.error("Got an error " + error.code + " : " + error.message);
 		}
-	});
+	);
 }
 
 exports.getDailyTotals = function(community, date, callback, failCallback) {
@@ -38,8 +38,8 @@ exports.getDailyTotals = function(community, date, callback, failCallback) {
 	queryDate.setHours(0, 0, 0, 0); //only year, month, day remain
 	totalQuery.equalTo("date", queryDate);
 	totalQuery.equalTo("community", community);
-	totalQuery.first({
-		success: function(object) {
+	totalQuery.first().then(
+		function(object) { //success
 			var dailyTotals = object;
 			if (!dailyTotals) {
 				console.log("CommunityDailyTotals not found, creating");
@@ -58,14 +58,14 @@ exports.getDailyTotals = function(community, date, callback, failCallback) {
 			}
 			callback(dailyTotals);
 		},
-		error: function(error) {
+		function(error) { // error
 			console.error("Got an error " + error.code + " : " + error.message);
 
 			if (failCallback) {
 				failCallback(error);
 			}
 		}
-	});
+	);
 }
 
 exports.getMonthlyTotals = function(community, date, callback, failCallback) {
@@ -77,8 +77,8 @@ exports.getMonthlyTotals = function(community, date, callback, failCallback) {
 	queryDate.setDate(1); //only year, month remain
 	totalQuery.equalTo("date", queryDate);
 	totalQuery.equalTo("community", community);
-	totalQuery.first({
-		success: function(object) {
+	totalQuery.first().then(
+		function(object) {
 			var monthlyTotals = object;
 			if (!monthlyTotals) {
 				console.log("CommunityMonthlyTotals not found, creating");
@@ -97,14 +97,14 @@ exports.getMonthlyTotals = function(community, date, callback, failCallback) {
 			}
 			callback(monthlyTotals);
 		},
-		error: function(error) {
+		function(error) {
 			console.error("Got an error " + error.code + " : " + error.message);
 
 			if (failCallback) {
 				failCallback(error);
 			}
 		}
-	});
+	);
 }
 
 exports.updateTotals = function(trip, totals) {

--- a/cloud/CommunityTotals.js
+++ b/cloud/CommunityTotals.js
@@ -20,7 +20,7 @@ exports.getAllTimeTotals = function(community, callback) {
 				allTimeTotals.set("missedCallCount", 0);
 				allTimeTotals.set("missedOtherCount", 0);
 				allTimeTotals.set("community", community);
-				allTimeTotals.save();
+				allTimeTotals.save({},{ useMasterKey: true });
 			}
 			callback(allTimeTotals);
 		},
@@ -54,7 +54,7 @@ exports.getDailyTotals = function(community, date, callback, failCallback) {
 				dailyTotals.set("missedCallCount", 0);
 				dailyTotals.set("missedOtherCount", 0);
 				dailyTotals.set("community", community);
-				dailyTotals.save();
+				dailyTotals.save({},{ useMasterKey: true });
 			}
 			callback(dailyTotals);
 		},
@@ -93,7 +93,7 @@ exports.getMonthlyTotals = function(community, date, callback, failCallback) {
 				monthlyTotals.set("missedCallCount", 0);
 				monthlyTotals.set("missedOtherCount", 0);
 				monthlyTotals.set("community", community);
-				monthlyTotals.save();
+				monthlyTotals.save({},{ useMasterKey: true });
 			}
 			callback(monthlyTotals);
 		},
@@ -136,6 +136,6 @@ exports.updateTotals = function(trip, totals) {
 		if (missedOtherCount) {
 			totals.increment("missedOtherCount", missedOtherCount);
 		}
-		totals.save();
+		totals.save({},{ useMasterKey: true });
 	}
 }

--- a/cloud/Driving.js
+++ b/cloud/Driving.js
@@ -9,15 +9,15 @@ Parse.Cloud.define("startedDriving", function(request, response) {
     var friendChannel = "friend-" + request.user.id
     var data = { userId: request.user.id };
 
-    // PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STARTED_DRIVING", data, pushCallbackCounter);
+    PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STARTED_DRIVING", data, pushCallbackCounter);
 
     var alert = {
         "loc-key": "notification-started-driving",
         "loc-args": [request.user.get("displayName")]
     };
-    // PushNotifications.sendIOSPush([driveChannel], alert, true, "startedDriving", data, pushCallbackCounter);
+    PushNotifications.sendIOSPush([driveChannel], alert, true, "startedDriving", data, pushCallbackCounter);
 
-    // PushNotifications.sendIOSPush([friendChannel], null, true, "startedDriving", data, pushCallbackCounter);
+    PushNotifications.sendIOSPush([friendChannel], null, true, "startedDriving", data, pushCallbackCounter);
 });
 
 Parse.Cloud.define("stoppedDriving", function(request, response) {
@@ -29,8 +29,8 @@ Parse.Cloud.define("stoppedDriving", function(request, response) {
     var friendChannel = "friend-" + request.user.id
     var data = { userId: request.user.id };
 
-    // PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STOPPED_DRIVING", data, pushCallbackCounter);
-    // PushNotifications.sendIOSPush([driveChannel, friendChannel], null, true, "stoppedDriving", data, pushCallbackCounter);
+    PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STOPPED_DRIVING", data, pushCallbackCounter);
+    PushNotifications.sendIOSPush([driveChannel, friendChannel], null, true, "stoppedDriving", data, pushCallbackCounter);
 });
 
 Parse.Cloud.define("sendEmergencyPush", function(request, response) {

--- a/cloud/Driving.js
+++ b/cloud/Driving.js
@@ -9,15 +9,15 @@ Parse.Cloud.define("startedDriving", function(request, response) {
     var friendChannel = "friend-" + request.user.id
     var data = { userId: request.user.id };
 
-    PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STARTED_DRIVING", data, pushCallbackCounter);
+    // PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STARTED_DRIVING", data, pushCallbackCounter);
 
     var alert = {
         "loc-key": "notification-started-driving",
         "loc-args": [request.user.get("displayName")]
     };
-    PushNotifications.sendIOSPush([driveChannel], alert, true, "startedDriving", data, pushCallbackCounter);
+    // PushNotifications.sendIOSPush([driveChannel], alert, true, "startedDriving", data, pushCallbackCounter);
 
-    PushNotifications.sendIOSPush([friendChannel], null, true, "startedDriving", data, pushCallbackCounter);
+    // PushNotifications.sendIOSPush([friendChannel], null, true, "startedDriving", data, pushCallbackCounter);
 });
 
 Parse.Cloud.define("stoppedDriving", function(request, response) {
@@ -29,8 +29,8 @@ Parse.Cloud.define("stoppedDriving", function(request, response) {
     var friendChannel = "friend-" + request.user.id
     var data = { userId: request.user.id };
 
-    PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STOPPED_DRIVING", data, pushCallbackCounter);
-    PushNotifications.sendIOSPush([driveChannel, friendChannel], null, true, "stoppedDriving", data, pushCallbackCounter);
+    // PushNotifications.sendAndroidPush([driveChannel], "ca.appcolony.distracteddriver.STOPPED_DRIVING", data, pushCallbackCounter);
+    // PushNotifications.sendIOSPush([driveChannel, friendChannel], null, true, "stoppedDriving", data, pushCallbackCounter);
 });
 
 Parse.Cloud.define("sendEmergencyPush", function(request, response) {

--- a/cloud/Installation.js
+++ b/cloud/Installation.js
@@ -10,17 +10,16 @@ Parse.Cloud.beforeSave(Parse.Installation, function(request, response) {
             id: installation.get("user").id
         });
 
-        userPointer.fetch({
-            success: function(user) {
+        userPointer.fetch({ useMasterKey: true }).then(
+            function(user) {
                 installation.set("channels", user.get("channels"));
                 response.success();
             },
-            error: function(myObject, error) {
+            function(myObject, error) {
                 console.error("Unable to find user " + userPointer.id + " " + error.code + " : " + error.message);
                 response.error();
-            },
-            useMasterKey:true
-        });
+            }
+        );
     } else {
         response.success();
     }

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -49,9 +49,8 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
 		if (request.user.id != friendUser.id) {
 		    var roleQuery = new Parse.Query(Parse.Role);
 		    roleQuery.equalTo("name", "user-" + request.user.id);
-		    roleQuery.first({
-		        success: function(role) {
-		            Parse.Cloud.useMasterKey();
+		    roleQuery.first({ useMasterKey: true }).then(
+		        function(role) {
 		            role.relation("users").add(friendUser);
 		            role.save(null, {
 		            	success: function(user) {
@@ -62,12 +61,12 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
   						}
 		            });
 		        },
-		        error: function(error) {
+		        function(error) {
 		            console.log("Failed to save role for friend relation with error " + error.code + " : " + error.message);
 					response.error("Unable to find the role");
 		        },
 		        useMasterKey:true
-		    });
+		    );
 		} else {
 			response.success();
 		}
@@ -85,8 +84,8 @@ Parse.Cloud.afterSave("POFriendRelation", function(request) {
 	var query = new Parse.Query("POFriendRequest");
 	query.equalTo("requestingUser", user);
 	query.equalTo("requestedUser", friendUser);
-	query.find({
-		success: function(results) {
+	query.find().then(
+		function(results) {
 			if (results.length > 0) {
 				for (var i = 0; i < results.length; i++) {
 					results[i].destroy();
@@ -96,23 +95,23 @@ Parse.Cloud.afterSave("POFriendRelation", function(request) {
 			var friendQuery = new Parse.Query("POFriendRequest");
 			friendQuery.equalTo("requestingUser", friendUser);
 			friendQuery.equalTo("requestedUser", user);
-			friendQuery.find({
-				success: function(results) {
+			friendQuery.find().then(
+				function(results) {
 					if (results.length > 0) {
 						for (var i = 0; i < results.length; i++) {
 							results[i].destroy();
 						}
 					}
 				},
-				error: function(error) {
+				function(error) {
 					console.log("error when destroying friend request");
 				}
-			});
+			);
 		},
-		error: function(error) {
+		function(error) {
 			console.log("error when destroying friend request");
 		}
-	});
+	);
 });
 
 

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -17,15 +17,15 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
 
 	function addAndRemoveChannels(addedChannel, removedChannel) {
 		request.user.remove("channels", removedChannel);
-		request.user.save(null, {
-            success: function(user) {
+		request.user.save().then(
+			function(user) {
 				request.user.addUnique("channels", addedChannel);
 				request.user.save(null, saveOptions);
 			},
-			error: function(user, error) {
+			function(user, error) {
 				response.error("Unable to save the user");
 			}
-        });
+        );
 	}
 
 	function updateChannelsIfNeeded() {

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -17,7 +17,7 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
 
 	function addAndRemoveChannels(addedChannel, removedChannel) {
 		request.user.remove("channels", removedChannel);
-		request.user.save().then(
+		request.user.save({},{ useMasterKey: true }).then(
 			function(user) {
 				request.user.addUnique("channels", addedChannel);
 				request.user.save(null, saveOptions);
@@ -52,7 +52,7 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
 		    roleQuery.first({ useMasterKey: true }).then(
 		        function(role) {
 		            role.relation("users").add(friendUser);
-		            role.save().then(
+		            role.save({},{ useMasterKey: true }).then(
 		            	function(user) {
 							updateChannelsIfNeeded();
 						},
@@ -127,7 +127,7 @@ Parse.Cloud.afterDelete("POFriendRelation", function(request) {
 		    roleQuery.first({ useMasterKey: true }).then(
 		        function(role) {
 		            role.relation("users").remove(friendUserPointer);
-		            role.save();
+		            role.save({},{ useMasterKey: true });
 		        },
 		        function(error) {
 		            console.log("Failed to remove role for friend relation with error " + error.code + " : " + error.message);

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -52,14 +52,14 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
 		    roleQuery.first({ useMasterKey: true }).then(
 		        function(role) {
 		            role.relation("users").add(friendUser);
-		            role.save(null, {
-		            	success: function(user) {
+		            role.save().then(
+		            	function(user) {
 							updateChannelsIfNeeded();
 						},
-						error: function(user, error) {
+						function(user, error) {
 							response.error("Unable to save the role");
   						}
-		            });
+		            );
 		        },
 		        function(error) {
 		            console.log("Failed to save role for friend relation with error " + error.code + " : " + error.message);
@@ -120,8 +120,8 @@ Parse.Cloud.afterDelete("POFriendRelation", function(request) {
 	var userPointer = request.object.get("user");
 	var friendUserPointer = request.object.get("friendUser");
 
-	userPointer.fetch({
-		success: function(user) {
+	userPointer.fetch({ useMasterKey: true }).then(
+		function(user) {
 		    var roleQuery = new Parse.Query(Parse.Role);
 		    roleQuery.equalTo("name", "user-" + user.id);
 		    roleQuery.first({ useMasterKey: true }).then(
@@ -136,9 +136,8 @@ Parse.Cloud.afterDelete("POFriendRelation", function(request) {
 			user.remove("channels", "friend-" + friendUserPointer.id);
 			user.save(null, {useMasterKey:true});
 		},
-		error: function(myObject, error) {
+		function(myObject, error) {
 			console.error("Unable to find user " + userPointer.id + " " + error.code + " : " + error.message);
-		},
-		useMasterKey: true
-	});
+		}
+	);
 });

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -6,21 +6,19 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
 
 	var friendUser = request.object.get("friendUser");
 
-	var saveOptions = {
-		success: function(user) {
-			response.success();
-		},
-		error: function(user, error) {
-			response.error("Unable to save the user");
-  		}
-	}
-
 	function addAndRemoveChannels(addedChannel, removedChannel) {
 		request.user.remove("channels", removedChannel);
 		request.user.save({},{ useMasterKey: true }).then(
 			function(user) {
 				request.user.addUnique("channels", addedChannel);
-				request.user.save(null, saveOptions);
+				request.user.save(null, { useMasterKey: true }).then(
+					function(user) {
+						response.success();
+					},
+					function(user, error) {
+						response.error("Unable to save the user");
+			  		}
+				);
 			},
 			function(user, error) {
 				response.error("Unable to save the user");

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -131,8 +131,7 @@ Parse.Cloud.afterDelete("POFriendRelation", function(request) {
 		        },
 		        function(error) {
 		            console.log("Failed to remove role for friend relation with error " + error.code + " : " + error.message);
-		        },
-		        useMasterKey:true
+		        }
 		    );
 			user.remove("channels", "friend-" + friendUserPointer.id);
 			user.save(null, {useMasterKey:true});

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -124,17 +124,16 @@ Parse.Cloud.afterDelete("POFriendRelation", function(request) {
 		success: function(user) {
 		    var roleQuery = new Parse.Query(Parse.Role);
 		    roleQuery.equalTo("name", "user-" + user.id);
-		    roleQuery.first({
-		        success: function(role) {
-		            Parse.Cloud.useMasterKey();
+		    roleQuery.first({ useMasterKey: true }).then(
+		        function(role) {
 		            role.relation("users").remove(friendUserPointer);
 		            role.save();
 		        },
-		        error: function(error) {
+		        function(error) {
 		            console.log("Failed to remove role for friend relation with error " + error.code + " : " + error.message);
 		        },
 		        useMasterKey:true
-		    });
+		    );
 			user.remove("channels", "friend-" + friendUserPointer.id);
 			user.save(null, {useMasterKey:true});
 		},

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -83,7 +83,7 @@ Parse.Cloud.afterSave("POFriendRelation", function(request) {
 	var query = new Parse.Query("POFriendRequest");
 	query.equalTo("requestingUser", user);
 	query.equalTo("requestedUser", friendUser);
-	query.find().then(
+	query.find({ useMasterKey: true }).then(
 		function(results) {
 			if (results.length > 0) {
 				for (var i = 0; i < results.length; i++) {
@@ -94,7 +94,7 @@ Parse.Cloud.afterSave("POFriendRelation", function(request) {
 			var friendQuery = new Parse.Query("POFriendRequest");
 			friendQuery.equalTo("requestingUser", friendUser);
 			friendQuery.equalTo("requestedUser", user);
-			friendQuery.find().then(
+			friendQuery.find({ useMasterKey: true }).then(
 				function(results) {
 					if (results.length > 0) {
 						for (var i = 0; i < results.length; i++) {

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -85,7 +85,7 @@ Parse.Cloud.afterSave("POFriendRelation", function(request) {
 		function(results) {
 			if (results.length > 0) {
 				for (var i = 0; i < results.length; i++) {
-					results[i].destroy();
+					results[i].destroy({ useMasterKey: true });
 				}
 			}
 
@@ -96,7 +96,7 @@ Parse.Cloud.afterSave("POFriendRelation", function(request) {
 				function(results) {
 					if (results.length > 0) {
 						for (var i = 0; i < results.length; i++) {
-							results[i].destroy();
+							results[i].destroy({ useMasterKey: true });
 						}
 					}
 				},

--- a/cloud/POFriendRelation.js
+++ b/cloud/POFriendRelation.js
@@ -64,8 +64,7 @@ Parse.Cloud.beforeSave("POFriendRelation", function(request, response) {
 		        function(error) {
 		            console.log("Failed to save role for friend relation with error " + error.code + " : " + error.message);
 					response.error("Unable to find the role");
-		        },
-		        useMasterKey:true
+		        }
 		    );
 		} else {
 			response.success();

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -78,13 +78,6 @@ Parse.Cloud.afterSave("POFriendRequest", function(request) {
 	    roleQuery.equalTo("name", "user-" + request.user.id);
 	    roleQuery.first({ useMasterKey: true }).then(
 	    	function(role) {
-	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
-	    		console.log("Inspect Role: \n\n");
-	    		console.log(role);
-	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
-	    		console.log("Requested User: \n\n");
-	    		console.log(request.object.get("requestedUser"));
-	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 	            role.relation("users").add(request.object.get("requestedUser"));
 	            role.save({},{ useMasterKey: true });
 	        },

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -86,7 +86,7 @@ Parse.Cloud.afterSave("POFriendRequest", function(request) {
 	    		console.log(request.object.get("requestedUser"));
 	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 	            role.relation("users").add(request.object.get("requestedUser"));
-	            role.save({ useMasterKey: true });
+	            role.save({},{ useMasterKey: true });
 	        },
 	        function(error) {
 	            console.log("Failed to save role for friend request with error " + error.code + " : " + error.message);

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -51,14 +51,14 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 							}
 						},
 						function(error) {
-							console.log("error when checking for existing relations, allowing to continute");
+							console.log("error when checking for existing relations, allowing to continue");
 							response.success();
 						}
 					);
 				}
 			},
 			function(error) {
-				console.log("error when checking for existing relations, allowing to continute");
+				console.log("error when checking for existing relations, allowing to continue");
 				response.success();
 			}
 		);
@@ -78,6 +78,10 @@ Parse.Cloud.afterSave("POFriendRequest", function(request) {
 	    roleQuery.equalTo("name", "user-" + request.user.id);
 	    roleQuery.first({ useMasterKey: true }).then(
 	    	function(role) {
+	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
+	    		console.log("Inspect Role: \n\n");
+	    		console.log(role);
+	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 	            role.relation("users").add(request.object.get("requestedUser"));
 	            role.save({ useMasterKey: true });
 	        },

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -78,7 +78,6 @@ Parse.Cloud.afterSave("POFriendRequest", function(request) {
 	    roleQuery.equalTo("name", "user-" + request.user.id);
 	    roleQuery.first({ useMasterKey: true }).then(
 	    	function(role) {
-	            Parse.Cloud.useMasterKey();
 	            role.relation("users").add(request.object.get("requestedUser"));
 	            role.save();
 	        },

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -14,8 +14,8 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 		var query = new Parse.Query("POFriendRelation");
 		query.equalTo("friendUserId", requestingUser);
 		query.equalTo("userId", requestedUser);
-		query.find({
-			success: function(results) {
+		query.find().then(
+			function(results) {
 				if (results.length > 0) {
 					console.log("Not allowed to create a friend request when already friends.");
 					response.error(JSON.stringify({
@@ -38,8 +38,8 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 					}
 
 					var query = Parse.Query.or(queryFriendRequest, queryInverseFriendRequest);
-					query.find({
-						success: function(results) {
+					query.find().then(
+						function(results) {
 							if (results.length > 0) {
 								console.log("Friend request already exists.");
 								response.error(JSON.stringify({
@@ -50,18 +50,18 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 								response.success();
 							}
 						},
-						error: function(error) {
+						function(error) {
 							console.log("error when checking for existing relations, allowing to continute");
 							response.success();
 						}
-					});
+					);
 				}
 			},
-			error: function(error) {
+			function(error) {
 				console.log("error when checking for existing relations, allowing to continute");
 				response.success();
 			}
-		});
+		);
 	} else {
 		console.log("Love thyself.");
 		response.error(JSON.stringify({
@@ -98,8 +98,8 @@ Parse.Cloud.afterDelete("POFriendRequest", function(request) {
 	queryInverseFriendRequest.equalTo("requestingUser", requestedUser);
 	queryInverseFriendRequest.equalTo("requestedUser", requestingUser);
 
-	queryInverseFriendRequest.find({
-		success: function(results) {
+	queryInverseFriendRequest.find().then(
+		function(results) {
 			Parse.Object.destroyAll(results, {
 				success: function() {},
 				error: function(error) {
@@ -107,10 +107,10 @@ Parse.Cloud.afterDelete("POFriendRequest", function(request) {
 				}
 			});
 		},
-		error: function(error) {
+		function(error) {
 			console.error("Error finding inverse friend relations " + error.code + ": " + error.message);
 		}
-	});
+	);
 });
 
 Parse.Cloud.define("requestedFriend", function(request, response) {

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -115,7 +115,7 @@ Parse.Cloud.afterDelete("POFriendRequest", function(request) {
 
 Parse.Cloud.define("requestedFriend", function(request, response) {
 
-	var pushCallbackCounter = new NetworkUtil.CallbackCounter(2, response);
+	var pushCallbackCounter = new NetworkUtil.CallbackCounter(1, response);
 
 	var channels = ["user-" + request.params.requested_user];
 
@@ -125,12 +125,12 @@ Parse.Cloud.define("requestedFriend", function(request, response) {
 	};
 	PushNotifications.sendAndroidPush(channels, "ca.appcolony.distracteddriver.FRIEND_REQUEST", androidPushData, pushCallbackCounter);
 
-	var alert = {
-		"loc-key": "notification-friend-request",
-		"loc-args": [request.user.get("displayName")]
-	};
-	var iOSData = {
-		userId: request.user.id
-	};
-	PushNotifications.sendIOSPush(channels, alert, true, "friendRequest", iOSData, pushCallbackCounter);
+	// var alert = {
+	// 	"loc-key": "notification-friend-request",
+	// 	"loc-args": [request.user.get("displayName")]
+	// };
+	// var iOSData = {
+	// 	userId: request.user.id
+	// };
+	// PushNotifications.sendIOSPush(channels, alert, true, "friendRequest", iOSData, pushCallbackCounter);
 });

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -122,8 +122,9 @@ Parse.Cloud.define("requestedFriend", function(request, response) {
 		userId: request.user.id,
 		userName: request.user.get("displayName")
 	};
+	console.log('\n\n %%%%%%%%%%% SEND FRIEND PUSH NOTIF %%%%%%%%%%%% \n\n');
 	PushNotifications.sendAndroidPush(channels, "ca.appcolony.distracteddriver.FRIEND_REQUEST", androidPushData, pushCallbackCounter);
-
+	console.log('\n\n %%%%%%%%%%% git  %%%%%%%%%%%% \n\n');
 	// var alert = {
 	// 	"loc-key": "notification-friend-request",
 	// 	"loc-args": [request.user.get("displayName")]

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -40,6 +40,10 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 					var query = Parse.Query.or(queryFriendRequest, queryInverseFriendRequest);
 					query.find().then(
 						function(results) {
+							console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
+							console.log("Results"+ " (length: " + results.length + "):\n");
+							console.log(results);
+							console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 							if (results.length > 0) {
 								console.log("Friend request already exists.");
 								response.error(JSON.stringify({

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -99,7 +99,7 @@ Parse.Cloud.afterDelete("POFriendRequest", function(request) {
 
 	queryInverseFriendRequest.find({ useMasterKey: true }).then(
 		function(results) {
-			Parse.Object.destroyAll().then(
+			Parse.Object.destroyAll({ useMasterKey: true }).then(
 				function() {},
 				function(error) {
 					console.error("Error deleting inverse friend relations " + error.code + ": " + error.message);

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -100,12 +100,12 @@ Parse.Cloud.afterDelete("POFriendRequest", function(request) {
 
 	queryInverseFriendRequest.find().then(
 		function(results) {
-			Parse.Object.destroyAll(results, {
-				success: function() {},
-				error: function(error) {
+			Parse.Object.destroyAll().then(
+				function() {},
+				function(error) {
 					console.error("Error deleting inverse friend relations " + error.code + ": " + error.message);
 				}
-			});
+			);
 		},
 		function(error) {
 			console.error("Error finding inverse friend relations " + error.code + ": " + error.message);

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -40,10 +40,6 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 					var query = Parse.Query.or(queryFriendRequest, queryInverseFriendRequest);
 					query.find({ useMasterKey: true }).then(
 						function(res) {
-							console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
-							console.log("Results"+ " (length: " + res.length + "):\n");
-							console.log(res);
-							console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 							if (res.length > 0) {
 								console.log("Friend request already exists.");
 								response.error(JSON.stringify({

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -38,7 +38,7 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 					}
 
 					var query = Parse.Query.or(queryFriendRequest, queryInverseFriendRequest);
-					query.find().then(
+					query.find({ useMasterKey: true }).then(
 						function(results) {
 							console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 							console.log("Results"+ " (length: " + results.length + "):\n");

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -14,7 +14,7 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 		var query = new Parse.Query("POFriendRelation");
 		query.equalTo("friendUserId", requestingUser);
 		query.equalTo("userId", requestedUser);
-		query.find().then(
+		query.find({ useMasterKey: true }).then(
 			function(results) {
 				if (results.length > 0) {
 					console.log("Not allowed to create a friend request when already friends.");
@@ -39,12 +39,12 @@ Parse.Cloud.beforeSave("POFriendRequest", function(request, response) {
 
 					var query = Parse.Query.or(queryFriendRequest, queryInverseFriendRequest);
 					query.find({ useMasterKey: true }).then(
-						function(results) {
+						function(res) {
 							console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
-							console.log("Results"+ " (length: " + results.length + "):\n");
-							console.log(results);
+							console.log("Results"+ " (length: " + res.length + "):\n");
+							console.log(res);
 							console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
-							if (results.length > 0) {
+							if (res.length > 0) {
 								console.log("Friend request already exists.");
 								response.error(JSON.stringify({
 									code: 1,
@@ -101,7 +101,7 @@ Parse.Cloud.afterDelete("POFriendRequest", function(request) {
 	queryInverseFriendRequest.equalTo("requestingUser", requestedUser);
 	queryInverseFriendRequest.equalTo("requestedUser", requestingUser);
 
-	queryInverseFriendRequest.find().then(
+	queryInverseFriendRequest.find({ useMasterKey: true }).then(
 		function(results) {
 			Parse.Object.destroyAll().then(
 				function() {},

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -82,6 +82,9 @@ Parse.Cloud.afterSave("POFriendRequest", function(request) {
 	    		console.log("Inspect Role: \n\n");
 	    		console.log(role);
 	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
+	    		console.log("Requested User: \n\n");
+	    		console.log(request.object.get("requestedUser"));
+	    		console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 	            role.relation("users").add(request.object.get("requestedUser"));
 	            role.save({ useMasterKey: true });
 	        },

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -122,9 +122,9 @@ Parse.Cloud.define("requestedFriend", function(request, response) {
 		userId: request.user.id,
 		userName: request.user.get("displayName")
 	};
-	console.log('\n\n %%%%%%%%%%% SEND FRIEND PUSH NOTIF %%%%%%%%%%%% \n\n');
+	
 	PushNotifications.sendAndroidPush(channels, "ca.appcolony.distracteddriver.FRIEND_REQUEST", androidPushData, pushCallbackCounter);
-	console.log('\n\n %%%%%%%%%%% git  %%%%%%%%%%%% \n\n');
+	
 	// var alert = {
 	// 	"loc-key": "notification-friend-request",
 	// 	"loc-args": [request.user.get("displayName")]

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -79,7 +79,7 @@ Parse.Cloud.afterSave("POFriendRequest", function(request) {
 	    roleQuery.first({ useMasterKey: true }).then(
 	    	function(role) {
 	            role.relation("users").add(request.object.get("requestedUser"));
-	            role.save();
+	            role.save({ useMasterKey: true });
 	        },
 	        function(error) {
 	            console.log("Failed to save role for friend request with error " + error.code + " : " + error.message);

--- a/cloud/POFriendRequest.js
+++ b/cloud/POFriendRequest.js
@@ -76,17 +76,16 @@ Parse.Cloud.afterSave("POFriendRequest", function(request) {
 	if (!request.object.existed()) {
 	    var roleQuery = new Parse.Query(Parse.Role);
 	    roleQuery.equalTo("name", "user-" + request.user.id);
-	    roleQuery.first({
-	        success: function(role) {
+	    roleQuery.first({ useMasterKey: true }).then(
+	    	function(role) {
 	            Parse.Cloud.useMasterKey();
 	            role.relation("users").add(request.object.get("requestedUser"));
 	            role.save();
 	        },
-	        error: function(error) {
+	        function(error) {
 	            console.log("Failed to save role for friend request with error " + error.code + " : " + error.message);
-	        },
-	        useMasterKey:true
-	    });
+	        }
+	    );
 	}
 
 });

--- a/cloud/POPublicUser.js
+++ b/cloud/POPublicUser.js
@@ -26,8 +26,8 @@ Parse.Cloud.afterSave("POPublicUser", function(request) {
     if (facebookId) {
         var query = new Parse.Query(POPublicUser);
         query.equalTo("facebookIdHashed", facebookId);
-        query.find({
-            success: function(results) {
+        query.find().then(
+            function(results) {
                 if (results.length > 0) {
                     for (var i = 0; i < results.length; i++) {
                         if (user.id != results[i].id) {
@@ -37,6 +37,6 @@ Parse.Cloud.afterSave("POPublicUser", function(request) {
                     }
                 }
             }
-        });
+        );
     }
 });

--- a/cloud/POPublicUser.js
+++ b/cloud/POPublicUser.js
@@ -26,7 +26,7 @@ Parse.Cloud.afterSave("POPublicUser", function(request) {
     if (facebookId) {
         var query = new Parse.Query(POPublicUser);
         query.equalTo("facebookIdHashed", facebookId);
-        query.find().then(
+        query.find({ useMasterKey: true }).then(
             function(results) {
                 if (results.length > 0) {
                     for (var i = 0; i < results.length; i++) {

--- a/cloud/POTrip.js
+++ b/cloud/POTrip.js
@@ -92,7 +92,6 @@ function checkTripValidity(trip) {
 }
 
 Parse.Cloud.define("userAggregateData", function(request, response) {
-	Parse.Cloud.useMasterKey();
 
 	var counts = {};
 	counts.sumSMS = 0;
@@ -108,8 +107,8 @@ Parse.Cloud.define("userAggregateData", function(request, response) {
 
 	var query = new Parse.Query("UserTotals");
 	query.equalTo("user", user);
-	query.first({
-		success: function(totals) {
+	query.first({ useMasterKey: true }).then(
+		function(totals) {
 			counts.sumSMS = totals.get("missedSMSCount");
 			counts.sumCall = totals.get("missedCallCount");
 			counts.sumOther = totals.get("missedOtherCount");
@@ -118,10 +117,10 @@ Parse.Cloud.define("userAggregateData", function(request, response) {
 			response.success(counts);
 
 		},
-		error: function(error) {
+		function(error) {
 			//this is valid if the user doesn't have any trips
 			console.log("Couldn't look up UserTotals for: "+request.params.userId);
 			response.success(counts);
 		}
-	});
+	);
 });

--- a/cloud/POTrip.js
+++ b/cloud/POTrip.js
@@ -16,20 +16,20 @@ Parse.Cloud.afterSave("POTrip", function(request) {
 	if (!trip.existed()) {
 		Totals.getGlobalTotals(function(globalTotals) {
 			Totals.updateTotals(trip, globalTotals);
-			globalTotals.save();
+			globalTotals.save({},{ useMasterKey: true });
 		});
 		Totals.getDailyTotals(trip.get("startTime"), function(dailyTotals) {
 			Totals.updateTotals(trip, dailyTotals);
-			dailyTotals.save();
+			dailyTotals.save({},{ useMasterKey: true });
 		});
 		Totals.getMonthlyTotals(trip.get("startTime"), function(monthlyTotals) {
 			Totals.updateTotals(trip, monthlyTotals);
-			monthlyTotals.save();
+			monthlyTotals.save({},{ useMasterKey: true });
 
 		});
 		Totals.getUserTotals(trip.get("userId"), function(userTotals) {
 			Totals.updateUserTotals(trip, userTotals);
-			userTotals.save();
+			userTotals.save({},{ useMasterKey: true });
 		});
 
 		var userQuery = new Parse.Query("User");

--- a/cloud/POTrip.js
+++ b/cloud/POTrip.js
@@ -33,8 +33,8 @@ Parse.Cloud.afterSave("POTrip", function(request) {
 		});
 
 		var userQuery = new Parse.Query("User");
-		userQuery.get(trip.get("userId"), {
-			success: function(user) {
+		userQuery.get(trip.get("userId")).then(
+			function(user) {
 				var community = user.get("community");
 				if (community != null) {
 					CommunityTotals.getAllTimeTotals(community, function(globalTotals) {
@@ -48,10 +48,10 @@ Parse.Cloud.afterSave("POTrip", function(request) {
 					});
 				}
 			},
-			error: function(object, error) {
+			function(object, error) {
 				console.error("Error when retrieving user to update stats " + error.code + " : " + error.message);
 			}
-		});
+		);
 	}
 });
 

--- a/cloud/Promotion.js
+++ b/cloud/Promotion.js
@@ -15,8 +15,8 @@ Parse.Cloud.define("getPromotion", function(request, response) {
 	promotionQuery.greaterThan("expiresAt", new Date());
 	promotionQuery.notEqualTo("viewedUsers", user);
 	
-	promotionQuery.first({
-		success: function(promotion) {
+	promotionQuery.first().then(
+		function(promotion) {
 			if (promotion) {
 				promotion.relation("viewedUsers").add(user);
 				promotion.save();
@@ -27,9 +27,9 @@ Parse.Cloud.define("getPromotion", function(request, response) {
 				response.success({});
 			}
 		},
-		error: function(error) {
+		function(error) {
 			console.error("Got an error " + error.code + " : " + error.message);
 			response.error();
 		}
-	});
+	);
 });

--- a/cloud/Promotion.js
+++ b/cloud/Promotion.js
@@ -19,7 +19,7 @@ Parse.Cloud.define("getPromotion", function(request, response) {
 		function(promotion) {
 			if (promotion) {
 				promotion.relation("viewedUsers").add(user);
-				promotion.save();
+				promotion.save({},{ useMasterKey: true });
 				var promotionJSON = {"url" : promotion.get("url")};
 				response.success(promotionJSON);
 			} else {

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -51,7 +51,7 @@ function sendPush(query, data, callbackCounter) {
         data: data
     }, { useMasterKey: true }).then(
         function(){
-            console.log('Push sent!');
+            // console.log('Push sent!');
         }, function(error) { // error
             console.error("Got an error " + error.code + " : " + error.message);
         }

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -52,12 +52,9 @@ function sendPush(query, data, callbackCounter) {
         data: data
     }, { useMasterKey: true }).then(
         function(){
-            console.log('\n\n %%%%%%%%%%% SEND PUSH NOTIF %%%%%%%%%%%% \n\n');
-            console.log('Push sent!');
-            console.log('\n\n %%%%%%%%%%% %%%%%%%%%%%% \n\n');
-            response.success();
+            callbackCounter.success();
         }, function(error) { // error
-            console.error("Got an error " + error.code + " : " + error.message);
+            callbackCounter.error(error);
         }
     );  
 }

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -57,9 +57,5 @@ function sendPush(query, data, callbackCounter) {
     Parse.Push.send({
         where: query,
         data: data
-    },
-    {
-        success: success,
-        error: error
-    }); 
+    }, { useMasterKey: true }).then(success, error);  
 }

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -46,16 +46,22 @@ exports.sendIOSPush = function(channels, alert, contentAvailable, category, data
 }
 
 function sendPush(query, data, callbackCounter) {
-    var success = function() {
-        callbackCounter.success();
-    }
-
-    var error = function(error) {
-        callbackCounter.error(error);
-    }
+    console.log("\n\n %%%%%%%%%%%%%%%%%%%%%%%%%% \n\n ");
+    console.log("Query");
+    console.log(query);
+    console.log("\n\n %%%%%%%%%%%%%%%%%%%%%%%%%% \n\n ");
+    console.log("Data");
+    console.log(data);
+    console.log("\n\n %%%%%%%%%%%%%%%%%%%%%%%%%% \n\n ");
 
     Parse.Push.send({
         where: query,
         data: data
-    }, { useMasterKey: true }).then(success, error);  
+    }, { useMasterKey: true }).then(
+        function(){
+            console.log('Push sent!');
+        }, function(error) { // error
+            console.error("Got an error " + error.code + " : " + error.message);
+        }
+    );  
 }

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -52,6 +52,7 @@ function sendPush(query, data, callbackCounter) {
     }, { useMasterKey: true }).then(
         function(){
             // console.log('Push sent!');
+            response.success();
         }, function(error) { // error
             console.error("Got an error " + error.code + " : " + error.message);
         }

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -46,14 +46,6 @@ exports.sendIOSPush = function(channels, alert, contentAvailable, category, data
 }
 
 function sendPush(query, data, callbackCounter) {
-    console.log("\n\n %%%%%%%%%%%%%%%%%%%%%%%%%% \n\n ");
-    console.log("Query");
-    console.log(query);
-    console.log("\n\n %%%%%%%%%%%%%%%%%%%%%%%%%% \n\n ");
-    console.log("Data");
-    console.log(data);
-    console.log("\n\n %%%%%%%%%%%%%%%%%%%%%%%%%% \n\n ");
-
     Parse.Push.send({
         where: query,
         data: data

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -10,9 +10,7 @@ exports.sendAndroidPush = function(channels, action, data, callbackCounter) {
             pushData[key] = data[key];
         };
     }
-    console.log('\n\n %%%%%%%%%%% SEND ANDROID PUSH NOTIF %%%%%%%%%%%% \n\n');
     sendPush(installationQuery, pushData, callbackCounter);
-    console.log('\n\n %%%%%%%%%%% %%%%%%%%%%%% \n\n');
 }
 
 exports.sendIOSPush = function(channels, alert, contentAvailable, category, data, callbackCounter) {

--- a/cloud/PushNotifications.js
+++ b/cloud/PushNotifications.js
@@ -10,8 +10,9 @@ exports.sendAndroidPush = function(channels, action, data, callbackCounter) {
             pushData[key] = data[key];
         };
     }
-
+    console.log('\n\n %%%%%%%%%%% SEND ANDROID PUSH NOTIF %%%%%%%%%%%% \n\n');
     sendPush(installationQuery, pushData, callbackCounter);
+    console.log('\n\n %%%%%%%%%%% %%%%%%%%%%%% \n\n');
 }
 
 exports.sendIOSPush = function(channels, alert, contentAvailable, category, data, callbackCounter) {
@@ -51,7 +52,9 @@ function sendPush(query, data, callbackCounter) {
         data: data
     }, { useMasterKey: true }).then(
         function(){
-            // console.log('Push sent!');
+            console.log('\n\n %%%%%%%%%%% SEND PUSH NOTIF %%%%%%%%%%%% \n\n');
+            console.log('Push sent!');
+            console.log('\n\n %%%%%%%%%%% %%%%%%%%%%%% \n\n');
             response.success();
         }, function(error) { // error
             console.error("Got an error " + error.code + " : " + error.message);

--- a/cloud/Stats.js
+++ b/cloud/Stats.js
@@ -485,8 +485,8 @@ Parse.Cloud.job("statForwardJob", function(request, status) {
 		// add rows for community totals and normal totals
 
 		var communityQuery = new Parse.Query("Community");
-		communityQuery.find({
-			success: function(results) {
+		communityQuery.find().then(
+			function(results) {
 				var callCount = 2;
 				callCount += results.length * 3;
 
@@ -536,8 +536,8 @@ Parse.Cloud.job("statForwardJob", function(request, status) {
 					});
 				};
 			},
-			error: function(error) {
+			function(error) {
 				status.error("error when loading communities to create total rows");
 			}
-		});
+		);
 });

--- a/cloud/Stats.js
+++ b/cloud/Stats.js
@@ -413,7 +413,7 @@ Parse.Cloud.define("communityStats", function(request, response) {
 	dailyQuery.lessThan("date",new Date());
 	dailyQuery.addDescending("date");
 	dailyQuery.limit(dayIntervals.length); //last 7 days of data
-	dailyQuery.find().then(
+	dailyQuery.find({ useMasterKey: true }).then(
 		function(dailyResults) {
 			responseObj.minutesDrivenDays = [];
 			responseObj.kmDrivenDays = [];
@@ -458,7 +458,7 @@ Parse.Cloud.define("communityStats", function(request, response) {
 
 	var allTimeQuery = new Parse.Query("CommunityAllTimeTotals");
 	allTimeQuery.equalTo("community", community);
-	allTimeQuery.first().then(
+	allTimeQuery.first({ useMasterKey: true }).then(
 		function(results) {
 			responseObj.missedMessages = results.get("missedSMSCount");
 			responseObj.missedCalls = results.get("missedCallCount");
@@ -485,7 +485,7 @@ Parse.Cloud.job("statForwardJob", function(request, status) {
 		// add rows for community totals and normal totals
 
 		var communityQuery = new Parse.Query("Community");
-		communityQuery.find().then(
+		communityQuery.find({ useMasterKey: true }).then(
 			function(results) {
 				var callCount = 2;
 				callCount += results.length * 3;

--- a/cloud/Stats.js
+++ b/cloud/Stats.js
@@ -104,7 +104,7 @@ Parse.Cloud.define("stats", function(request, response) {
 
 				var userTotalsQuery = new Parse.Query("UserTotals");
 				userTotalsQuery.containedIn("user", friends);
-				userTotalsQuery.find().then(
+				userTotalsQuery.find({ useMasterKey: true }).then(
 					function(userTotals) { //success
 						responseObj.friends = friendsStatsFromUserTotals(userTotals, dayIntervals, monthIntervals);
 						if (--queryCount == 0 && !failureFlag) {

--- a/cloud/Totals.js
+++ b/cloud/Totals.js
@@ -106,7 +106,7 @@ exports.getUserTotals = function(userId, callback, failCallback) {
 		id: userId
 	});
 	totalQuery.equalTo("user", user);
-	totalQuery.first().then(
+	totalQuery.first({ useMasterKey: true }).then(
 		function(object) {
 			var userTotals = object;
 			if (!userTotals) {

--- a/cloud/Totals.js
+++ b/cloud/Totals.js
@@ -4,8 +4,8 @@ exports.getGlobalTotals = function(callback) {
 	//retrieve the globalTotals object, create with defaults if necessary
 	var GlobalTotals = Parse.Object.extend("GlobalTotals");
 	var totalQuery = new Parse.Query(GlobalTotals);
-	totalQuery.first({
-		success: function(object) {
+	totalQuery.first().then(
+		function(object) {
 			var globalTotals = object;
 			if (!globalTotals) {
 				console.log("GlobalTotals not found, creating");
@@ -21,10 +21,10 @@ exports.getGlobalTotals = function(callback) {
 			}
 			callback(globalTotals);
 		},
-		error: function(error) {
+		function(error) {
 			console.error("Got an error " + error.code + " : " + error.message);
 		}
-	});
+	);
 }
 
 exports.getDailyTotals = function(date, callback, failCallback) {
@@ -34,8 +34,8 @@ exports.getDailyTotals = function(date, callback, failCallback) {
 	var queryDate = new Date(date);
 	queryDate.setHours(0, 0, 0, 0); //only year, month, day remain
 	totalQuery.equalTo("date", queryDate);
-	totalQuery.first({
-		success: function(object) {
+	totalQuery.first().then(
+		function(object) {
 			var dailyTotals = object;
 			if (!dailyTotals) {
 				console.log("DailyTotals not found, creating");
@@ -52,14 +52,14 @@ exports.getDailyTotals = function(date, callback, failCallback) {
 			}
 			callback(dailyTotals);
 		},
-		error: function(error) {
+		function(error) {
 			console.error("Got an error " + error.code + " : " + error.message);
 
 			if (failCallback) {
 				failCallback(error);
 			}
 		}
-	});
+	);
 }
 
 exports.getMonthlyTotals = function(date, callback, failCallback) {
@@ -70,8 +70,8 @@ exports.getMonthlyTotals = function(date, callback, failCallback) {
 	queryDate.setHours(0, 0, 0, 0);
 	queryDate.setDate(1); //only year, month remain
 	totalQuery.equalTo("date", queryDate);
-	totalQuery.first({
-		success: function(object) {
+	totalQuery.first().then(
+		function(object) {
 			var monthlyTotals = object;
 			if (!monthlyTotals) {
 				console.log("MonthlyTotals not found, creating");
@@ -88,14 +88,14 @@ exports.getMonthlyTotals = function(date, callback, failCallback) {
 			}
 			callback(monthlyTotals);
 		},
-		error: function(error) {
+		function(error) {
 			console.error("Got an error " + error.code + " : " + error.message);
 
 			if (failCallback) {
 				failCallback(error);
 			}
 		}
-	});
+	);
 }
 
 exports.getUserTotals = function(userId, callback, failCallback) {
@@ -106,8 +106,8 @@ exports.getUserTotals = function(userId, callback, failCallback) {
 		id: userId
 	});
 	totalQuery.equalTo("user", user);
-	totalQuery.first({
-		success: function(object) {
+	totalQuery.first().then(
+		function(object) {
 			var userTotals = object;
 			if (!userTotals) {
 
@@ -139,14 +139,14 @@ exports.getUserTotals = function(userId, callback, failCallback) {
 			}
 			callback(userTotals);
 		},
-		error: function(error) {
+		function(error) {
 			console.error("Got an error " + error.code + " : " + error.message);
 
 			if (failCallback) {
 				failCallback(error);
 			}
 		}
-	});
+	);
 }
 
 exports.updateTotals = function(trip, totals) {

--- a/cloud/Totals.js
+++ b/cloud/Totals.js
@@ -17,7 +17,7 @@ exports.getGlobalTotals = function(callback) {
 				globalTotals.set("missedSMSCount", 0);
 				globalTotals.set("missedCallCount", 0);
 				globalTotals.set("missedOtherCount", 0);
-				globalTotals.save();
+				globalTotals.save({},{ useMasterKey: true });
 			}
 			callback(globalTotals);
 		},
@@ -48,7 +48,7 @@ exports.getDailyTotals = function(date, callback, failCallback) {
 				dailyTotals.set("missedSMSCount", 0);
 				dailyTotals.set("missedCallCount", 0);
 				dailyTotals.set("missedOtherCount", 0);
-				dailyTotals.save();
+				dailyTotals.save({},{ useMasterKey: true });
 			}
 			callback(dailyTotals);
 		},
@@ -84,7 +84,7 @@ exports.getMonthlyTotals = function(date, callback, failCallback) {
 				monthlyTotals.set("missedSMSCount", 0);
 				monthlyTotals.set("missedCallCount", 0);
 				monthlyTotals.set("missedOtherCount", 0);
-				monthlyTotals.save();
+				monthlyTotals.save({},{ useMasterKey: true });
 			}
 			callback(monthlyTotals);
 		},
@@ -132,7 +132,7 @@ exports.getUserTotals = function(userId, callback, failCallback) {
 				userTotals.set("distanceTravelled", 0);
 				userTotals.set("minutesTravelled", 0);
 				userTotals.set("user", user);
-				userTotals.save();
+				userTotals.save({},{ useMasterKey: true });
 
 				// console.log("UserTotals creating:"+JSON.stringify(userTotals));
 

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -173,15 +173,15 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
     });
     console.log("Saw " + request.params.userId + ". ShortCode: " + request.params.phoneShortCode);
 
-    userPointer.fetch({
-        success: function(user) {
+    userPointer.fetch().then(
+        function(user) {
             var serverShortCode = user.get("phoneShortCode");
 
             if (serverShortCode == request.params.phoneShortCode) {
 
                 user.set("phoneNumberVerified", true);
-                user.save(null, {
-                    success: function() {
+                user.save().then(
+                    function() {
 
                         //load sha256 library
                         var jssha = require('./jssha256.js');
@@ -252,21 +252,21 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
                         });
 
                     },
-                    error: function(myObject, error) {
+                    function(myObject, error) {
                         console.error("Error when setting phoneNumberVerified " + error.code + " : " + error.message);
                         response.error("Error when setting phoneNumberVerified");
                     }
-                });
+                );
             } else {
                 console.error("Invalid shortcode sent for " + request.params.userId + ". Expecting: " + serverShortCode + " Recieved: " + request.params.phoneShortCode);
                 response.error("Invalid shortcode sent");
             }
         },
-        error: function(myObject, error) {
+        function(myObject, error) {
             console.error("Unable to find user to verify " + error.code + " : " + error.message);
             response.error("Unable to find user to verify");
         }
-    });
+    );
 });
 
 Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
@@ -276,8 +276,8 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
     var userPointer = new Parse.User({
         id: request.params.userId
     });
-    userPointer.fetch({
-        success: function(user) {
+    userPointer.fetch().then(
+        function(user) {
             console.log("user: " + user);
 
             var phoneShortCode = Math.floor((Math.random() * 900000) + 100000);
@@ -302,9 +302,9 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
             });
 
         },
-        error: function(myObject, error) {
+        function(myObject, error) {
             console.error("Unable to find user to send shortcode " + error.code + " : " + error.message);
             response.error("Unable to find user to verify");
         }
-    });
+    );
 });

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -270,13 +270,11 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
 });
 
 Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
-    Parse.Cloud.useMasterKey();
-
     console.log("user id: " + request.params.userId);
     var userPointer = new Parse.User({
         id: request.params.userId
     });
-    userPointer.fetch().then(
+    userPointer.fetch({ useMasterKey: true }).then(
         function(user) {
             console.log("user: " + user);
 

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -108,8 +108,8 @@ Parse.Cloud.afterSave(Parse.User, function(request) {
     if (dirtyKeys.indexOf("channels") > -1) {
         var installationQuery = new Parse.Query(Parse.Installation);
         installationQuery.equalTo("user", user);
-        installationQuery.find({
-            success: function(installations) {
+        installationQuery.find({ useMasterKey: true }).then(
+            function(installations) {
                 if (installations) {
                     for (var i = 0; i < installations.length; i++) {
                         var installation = installations[i];
@@ -120,11 +120,10 @@ Parse.Cloud.afterSave(Parse.User, function(request) {
                     }
                 }
             },
-            error: function(error) {
+            function(error) {
                 console.error("Unable to find installation " + error.code + " : " + error.message);
-            },
-            useMasterKey:true
-        });
+            }
+        );
     }
 
     for (var i in dirtyKeys) {

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -77,30 +77,30 @@ Parse.Cloud.afterSave(Parse.User, function(request) {
         console.log("added new user");
         Totals.getDailyTotals(new Date(), function(dailyTotals) {
             dailyTotals.increment("users");
-            dailyTotals.save();
+            dailyTotals.save({},{ useMasterKey: true });
         });
 
         Totals.getMonthlyTotals(new Date(), function(monthlyTotals) {
             monthlyTotals.increment("users");
-            monthlyTotals.save();
+            monthlyTotals.save({},{ useMasterKey: true });
         });
 
         Totals.getGlobalTotals(function(globalTotals) {
             globalTotals.increment("users");
-            globalTotals.save();
+            globalTotals.save({},{ useMasterKey: true });
         });
 
         //https://www.parse.com/questions/errors-when-trying-to-set-acls-in-user-beforesave
         var roleACL = new Parse.ACL();
         roleACL.setPublicReadAccess(true);
         var role = new Parse.Role("user-" + user.id, roleACL);
-        role.save();
+        role.save({},{ useMasterKey: true });
 
         var userACL = new Parse.ACL(user);
         userACL.setRoleReadAccess("user-" + user.id, true);
         user.setACL(userACL);
         user.addUnique("channels", "user-" + user.id);
-        user.save();
+        user.save({},{ useMasterKey: true });
     }
 
     var dirtyKeys = request.object.get("dirtyKeys");
@@ -180,7 +180,7 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
             if (serverShortCode == request.params.phoneShortCode) {
 
                 user.set("phoneNumberVerified", true);
-                user.save().then(
+                user.save({},{ useMasterKey: true }).then(
                     function() {
 
                         //load sha256 library
@@ -279,7 +279,7 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
 
             var phoneShortCode = Math.floor((Math.random() * 900000) + 100000);
             user.set("phoneShortCode", phoneShortCode);
-            user.save();
+            user.save({},{ useMasterKey: true });
 
             var formattedPhoneShortCode = phoneShortCode.toString()
             formattedPhoneShortCode = formattedPhoneShortCode.slice(0, 3) + " " + formattedPhoneShortCode.slice(3);

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -173,7 +173,7 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
     });
     console.log("Saw " + request.params.userId + ". ShortCode: " + request.params.phoneShortCode);
 
-    userPointer.fetch().then(
+    userPointer.fetch({useMasterKey:true}).then(
         function(user) {
             var serverShortCode = user.get("phoneShortCode");
 
@@ -197,7 +197,7 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
 
                         var queryPublicUsersWithPhone = new Parse.Query(POPublicUser);
                         queryPublicUsersWithPhone.equalTo("phoneNumberHashed", hashedPhoneNumber);
-                        queryPublicUsersWithPhone.find(function(publicUsers) {
+                        queryPublicUsersWithPhone.find({useMasterKey:true}).then(function(publicUsers) {
 
                             //null out any existing users with this phone number
                             for (var i = 0; i < publicUsers.length; i++) {
@@ -238,7 +238,7 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
                                 publicUser.set("user", userPointer);
                             }
                             publicUser.set("phoneNumberHashed", hashedPhoneNumber);
-                            return publicUser.save(null, {useMasterKey:true});
+                            return publicUser.save({}, {useMasterKey:true});
 
                         }).then(function() {
 

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -150,7 +150,7 @@ Parse.Cloud.afterSave(Parse.User, function(request) {
             //find the current public user
             var query = new Parse.Query(POPublicUser);
             query.equalTo("user", request.object);
-            query.first().then(function(object) {
+            query.first({ useMasterKey: true }).then(function(object) {
 
                 //save public user with hashed phone number for search
                 var publicUser = object;
@@ -176,6 +176,10 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
     userPointer.fetch({useMasterKey:true}).then(
         function(user) {
             var serverShortCode = user.get("phoneShortCode");
+            console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
+            console.log("serverShortCode:\n");
+            console.log(serverShortCode);
+            console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 
             if (serverShortCode == request.params.phoneShortCode) {
 

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -250,7 +250,6 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
                             response.error("Error saving phone number");
 
                         });
-
                     },
                     function(myObject, error) {
                         console.error("Error when setting phoneNumberVerified " + error.code + " : " + error.message);

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -285,22 +285,21 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
             formattedPhoneShortCode = formattedPhoneShortCode.slice(0, 3) + " " + formattedPhoneShortCode.slice(3);
 
             console.log('\n\n%%%%%%%%%\n\n');
-            console.log('TWilio \n');
-            
+            console.log('TWilio');
+            console.log('\n\n%%%%%%%%%\n\n');
             //TODO send shortcode from twilio
-            twilio.sendSMS({
+            twilio.sendMessage({
                 From: "+15873170710",
                 To: user.get("phoneNumber"),
                 Body: "Thanks for using OneTap!  Your code is " + formattedPhoneShortCode
-            }).then(
-                function(httpResponse) {
+            }, {
+                success: function(httpResponse) {
                     response.success();
                 },
-                function(httpResponse) {
+                error: function(httpResponse) {
                     response.error("unable to send shortcode from twilio: " + httpResponse);
                 }
-            );
-            console.log('\n\n%%%%%%%%%\n\n');
+            });
 
         },
         function(myObject, error) {

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -284,10 +284,6 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
             var formattedPhoneShortCode = phoneShortCode.toString()
             formattedPhoneShortCode = formattedPhoneShortCode.slice(0, 3) + " " + formattedPhoneShortCode.slice(3);
 
-            console.log('\n\n%%%%%%%%%\n\n');
-            console.log('TWilio');
-            console.log('\n\n%%%%%%%%%\n\n');
-            //TODO send shortcode from twilio
             twilio.sendMessage({
                 From: "+15873170710",
                 To: user.get("phoneNumber"),

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -292,14 +292,14 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
                 From: "+15873170710",
                 To: user.get("phoneNumber"),
                 Body: "Thanks for using OneTap!  Your code is " + formattedPhoneShortCode
-            }, {
-                success: function(httpResponse) {
+            }).then(
+                function(httpResponse) {
                     response.success();
                 },
-                error: function(httpResponse) {
+                function(httpResponse) {
                     response.error("unable to send shortcode from twilio: " + httpResponse);
                 }
-            });
+            );
 
         },
         function(myObject, error) {

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -176,10 +176,6 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
     userPointer.fetch({useMasterKey:true}).then(
         function(user) {
             var serverShortCode = user.get("phoneShortCode");
-            console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
-            console.log("serverShortCode:\n");
-            console.log(serverShortCode);
-            console.log("\n\n%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n\n");
 
             if (serverShortCode == request.params.phoneShortCode) {
 
@@ -288,19 +284,22 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
             var formattedPhoneShortCode = phoneShortCode.toString()
             formattedPhoneShortCode = formattedPhoneShortCode.slice(0, 3) + " " + formattedPhoneShortCode.slice(3);
 
+            console.log('\n\n%%%%%%%%%\n\n');
+            console.log('TWilio');
+            console.log('\n\n%%%%%%%%%\n\n');
             //TODO send shortcode from twilio
-            twilio.sendSMS({
-                From: "+15873170710",
-                To: user.get("phoneNumber"),
-                Body: "Thanks for using OneTap!  Your code is " + formattedPhoneShortCode
-            }, {
-                success: function(httpResponse) {
-                    response.success();
-                },
-                error: function(httpResponse) {
-                    response.error("unable to send shortcode from twilio: " + httpResponse);
-                }
-            });
+            // twilio.sendSMS({
+            //     From: "+15873170710",
+            //     To: user.get("phoneNumber"),
+            //     Body: "Thanks for using OneTap!  Your code is " + formattedPhoneShortCode
+            // }, {
+            //     success: function(httpResponse) {
+            //         response.success();
+            //     },
+            //     error: function(httpResponse) {
+            //         response.error("unable to send shortcode from twilio: " + httpResponse);
+            //     }
+            // });
 
         },
         function(myObject, error) {

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -227,7 +227,7 @@ Parse.Cloud.define("verifyPhoneShortCode", function(request, response) {
                             //find the current public user
                             var query = new Parse.Query(POPublicUser);
                             query.equalTo("user", userPointer);
-                            return query.first();
+                            return query.first({useMasterKey:true});
 
                         }).then(function(object) {
 

--- a/cloud/User.js
+++ b/cloud/User.js
@@ -285,21 +285,22 @@ Parse.Cloud.define("sendPhoneShortCode", function(request, response) {
             formattedPhoneShortCode = formattedPhoneShortCode.slice(0, 3) + " " + formattedPhoneShortCode.slice(3);
 
             console.log('\n\n%%%%%%%%%\n\n');
-            console.log('TWilio');
-            console.log('\n\n%%%%%%%%%\n\n');
+            console.log('TWilio \n');
+            
             //TODO send shortcode from twilio
-            // twilio.sendSMS({
-            //     From: "+15873170710",
-            //     To: user.get("phoneNumber"),
-            //     Body: "Thanks for using OneTap!  Your code is " + formattedPhoneShortCode
-            // }, {
-            //     success: function(httpResponse) {
-            //         response.success();
-            //     },
-            //     error: function(httpResponse) {
-            //         response.error("unable to send shortcode from twilio: " + httpResponse);
-            //     }
-            // });
+            twilio.sendSMS({
+                From: "+15873170710",
+                To: user.get("phoneNumber"),
+                Body: "Thanks for using OneTap!  Your code is " + formattedPhoneShortCode
+            }).then(
+                function(httpResponse) {
+                    response.success();
+                },
+                function(httpResponse) {
+                    response.error("unable to send shortcode from twilio: " + httpResponse);
+                }
+            );
+            console.log('\n\n%%%%%%%%%\n\n');
 
         },
         function(myObject, error) {

--- a/cloud/main.js
+++ b/cloud/main.js
@@ -11,3 +11,7 @@ require('./Community.js');
 require('./User.js');
 require('./Installation.js');
 
+Parse.Cloud.define('hello', function(req, res) {
+  res.success('Hi');
+});
+

--- a/index.js
+++ b/index.js
@@ -22,9 +22,6 @@ var api = new ParseServer({
     classNames: ["Posts", "Comments"] // List of classes to support for query subscriptions
   }
 });
-console.log("SERVER URL\n")
-console.log(process.env.SERVER_URL);
-console.log("\n\n\n");
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server
 // If you wish you require them, you can set them as options in the initialization above:
 // javascriptKey, restAPIKey, dotNetKey, clientKey

--- a/index.js
+++ b/index.js
@@ -27,6 +27,14 @@ var api = new ParseServer({
       senderId: process.env.FIREBASE_SENDER_ID || '', // The Sender ID of GCM
       apiKey: process.env.FIREBASE_SERVER_KEY || '' // The Server API Key of GCM
     }
+  },
+  emailAdapter: {
+    module: 'parse-server-simple-mailgun-adapter',
+    options: {
+      fromAddress: process.env.MAILGUN_FROM_ADDRESS || '', // The address that your emails come from
+      domain: process.env.MAILGUN_DOMAIN || '',// Your domain from mailgun.com
+      apiKey: process.env.MAILGUN_API_KEY || '' // Your API key from mailgun.com
+    }
   }
 });
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server

--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ var api = new ParseServer({
   serverURL: process.env.SERVER_URL || 'http://localhost:1337/parse',  // Don't forget to change to https if needed
   liveQuery: {
     classNames: ["Posts", "Comments"] // List of classes to support for query subscriptions
+  },
+  push: {
+    android: {
+      senderId: process.env.FIREBASE_SENDER_ID || '', // The Sender ID of GCM
+      apiKey: process.env.FIREBASE_SERVER_KEY || '' // The Server API Key of GCM
+    }
   }
 });
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // compatible API routes.
 
 var express = require('express');
-var morgan = require('morgan');
+// var morgan = require('morgan');
 var ParseServer = require('parse-server').ParseServer;
 var path = require('path');
 
@@ -16,6 +16,7 @@ var api = new ParseServer({
   databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
   appId: process.env.APP_ID || 'myAppId',
+  verbose: process.env.VERBOSE || false,
   masterKey: process.env.MASTER_KEY || '', //Add your master key here. Keep it secret!
   serverURL: process.env.SERVER_URL || 'http://localhost:1337/parse',  // Don't forget to change to https if needed
   liveQuery: {
@@ -33,7 +34,7 @@ var api = new ParseServer({
 // javascriptKey, restAPIKey, dotNetKey, clientKey
 
 var app = express();
-app.use(morgan('combined'));
+// app.use(morgan('combined'));
 
 // Serve static assets from the /public folder
 app.use('/public', express.static(path.join(__dirname, '/public')));

--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ var api = new ParseServer({
     classNames: ["Posts", "Comments"] // List of classes to support for query subscriptions
   }
 });
+console.log("SERVER URL\n")
+console.log(process.env.SERVER_URL);
+console.log("\n\n\n");
 // Client-keys like the javascript key or the .NET key are not necessary with parse-server
 // If you wish you require them, you can set them as options in the initialization above:
 // javascriptKey, restAPIKey, dotNetKey, clientKey

--- a/scripts/parse_rest/cloudcode/cloud/main.js
+++ b/scripts/parse_rest/cloudcode/cloud/main.js
@@ -9,16 +9,16 @@ Parse.Cloud.define("hello", function(request, response) {
 Parse.Cloud.define("averageStars", function(request, response) {
   var query = new Parse.Query("Review");
   query.equalTo("movie", request.params.movie);
-  query.find({
-    success: function(results) {
+  query.find().then(
+    function(results) {
       var sum = 0;
       for (var i = 0; i < results.length; ++i) {
         sum += results[i].get("stars");
       }
       response.success(sum / results.length);
     },
-    error: function() {
+    function() {
       response.error("movie lookup failed");
     }
-  });
+  );
 });

--- a/scripts/parse_rest/cloudcode/cloud/main.js
+++ b/scripts/parse_rest/cloudcode/cloud/main.js
@@ -9,7 +9,7 @@ Parse.Cloud.define("hello", function(request, response) {
 Parse.Cloud.define("averageStars", function(request, response) {
   var query = new Parse.Query("Review");
   query.equalTo("movie", request.params.movie);
-  query.find().then(
+  query.find({ useMasterKey: true }).then(
     function(results) {
       var sum = 0;
       for (var i = 0; i < results.length; ++i) {


### PR DESCRIPTION
Convert now-unsupported parse _find_, _first_ methods to follow promises styling.

Also, convert `Parse.Cloud.useMasterKey()` to new styling of `{ useMasterKey: true }`. 

- [migration guide link](https://www.appcoda.com/parse-migration-part3/)
- [parse's promises documentation](http://parseplatform.github.io/docs/js/guide/#promises)
